### PR TITLE
feat(ui): add proper cursor styles to interactive components

### DIFF
--- a/components/selia/autocomplete.tsx
+++ b/components/selia/autocomplete.tsx
@@ -218,11 +218,11 @@ export function AutocompleteItem({
       data-slot="autocomplete-item"
       {...props}
       className={cn(
-        'flex items-center gap-3.5 text-foreground px-3 py-2.5 rounded cursor-default',
+        'flex items-center gap-3.5 text-foreground px-3 py-2.5 rounded cursor-pointer',
         'data-[highlighted]:bg-popover-accent data-[selected]:bg-popover-accent',
         'focus-visible:outline-none',
         '[&_svg:not([class*=size-])]:size-4 [&_svg:not([class*=text-])]:text-foreground',
-        'data-disabled:opacity-50 data-disabled:pointer-events-none',
+        'data-disabled:cursor-not-allowed data-disabled:opacity-50 data-disabled:pointer-events-none',
         className,
       )}
     />

--- a/components/selia/button.tsx
+++ b/components/selia/button.tsx
@@ -7,14 +7,14 @@ import { Button as BaseButton } from '@base-ui/react/button';
 
 export const buttonVariants = cva(
   [
-    'relative font-medium select-none',
+    'relative font-medium select-none cursor-pointer',
     'inline-flex justify-center items-center gap-2.5 transition-colors',
     'after:absolute after:inset-0 after:bg-white/15 after:opacity-0 hover:after:opacity-100',
     'active:after:opacity-100 data-popup-open:after:opacity-100 after:transition-opacity',
     'focus:outline-0 focus-visible:outline-2 focus-visible:outline-offset-2',
     'before:size-4.5 before:bg-spinner before:-mr-7 before:opacity-0 before:scale-20 before:transition-[opacity,scale,margin-right]',
     '[&>svg]:opacity-100 [&>svg]:transition-[opacity,scale,margin-right] [&>svg:not([class*=text-])]:text-current',
-    'disabled:opacity-70 disabled:pointer-events-none data-disabled:opacity-70 data-disabled:pointer-events-none',
+    'disabled:cursor-not-allowed disabled:opacity-70 disabled:pointer-events-none data-disabled:cursor-not-allowed data-disabled:opacity-70 data-disabled:pointer-events-none',
   ],
   {
     variants: {
@@ -71,7 +71,7 @@ export const buttonVariants = cva(
       },
       progress: {
         true: [
-          'pointer-events-none opacity-70 [&>svg]:opacity-0 [&>svg]:scale-0 [&>svg]:-mr-7',
+          'cursor-progress pointer-events-none opacity-70 [&>svg]:opacity-0 [&>svg]:scale-0 [&>svg]:-mr-7',
           'before:size-4.5 before:bg-spinner before:animate-spin before:mr-0 before:opacity-100 before:scale-100',
         ],
       },

--- a/components/selia/checkbox.tsx
+++ b/components/selia/checkbox.tsx
@@ -41,11 +41,11 @@ export function Checkbox({
       data-slot="checkbox"
       {...props}
       className={cn(
-        'size-4 shrink-0 flex items-center justify-center rounded-xs border border-input-border bg-input shadow-input',
+        'size-4 shrink-0 flex items-center justify-center rounded-xs border border-input-border bg-input shadow-input cursor-pointer',
         'focus:outline-0 focus-visible:outline-2 focus-visible:outline-offset-2 outline-primary',
         'data-[checked]:bg-primary data-[checked]:border-primary',
         'transition-colors duration-75 hover:border-input-accent-border',
-        'data-disabled:opacity-70 data-disabled:pointer-events-none',
+        'data-disabled:cursor-not-allowed data-disabled:opacity-70 data-disabled:pointer-events-none',
         props.className,
       )}
     >

--- a/components/selia/combobox.tsx
+++ b/components/selia/combobox.tsx
@@ -17,8 +17,8 @@ export const comboboxTriggerVariants = cva(
     'px-2.5 w-full bg-input rounded placeholder:text-dimmed transition-all',
     'focus:outline-0 focus:ring-primary focus:ring-2',
     'has-focus:ring-primary has-focus:ring-2',
-    'flex items-center gap-2.5 cursor-default',
-    'data-disabled:opacity-70 data-disabled:pointer-events-none',
+    'flex items-center gap-2.5 cursor-pointer',
+    'data-disabled:cursor-not-allowed data-disabled:opacity-70 data-disabled:pointer-events-none',
   ],
   {
     variants: {
@@ -291,11 +291,11 @@ export function ComboboxItem({
       data-slot="combobox-item"
       {...props}
       className={cn(
-        'flex items-center text-popover-foreground gap-3.5 py-2.5 px-3 rounded select-none',
+        'flex items-center text-popover-foreground gap-3.5 py-2.5 px-3 rounded select-none cursor-pointer',
         'group-data-[side=none]:min-w-[calc(var(--anchor-width))]',
         'data-[highlighted]:bg-popover-accent data-[selected]:bg-popover-accent',
         'focus-visible:outline-none',
-        'data-disabled:opacity-70 data-disabled:pointer-events-none',
+        'data-disabled:cursor-not-allowed data-disabled:opacity-70 data-disabled:pointer-events-none',
         className,
       )}
     >

--- a/components/selia/label.tsx
+++ b/components/selia/label.tsx
@@ -6,7 +6,7 @@ export function Label({ className, ...props }: React.ComponentProps<'label'>) {
   return (
     <label
       data-slot="label"
-      className={cn('text-foreground flex items-center gap-3', className)}
+      className={cn('text-foreground flex items-center gap-3 cursor-pointer', className)}
       {...props}
     />
   );

--- a/components/selia/menu.tsx
+++ b/components/selia/menu.tsx
@@ -104,13 +104,13 @@ export function MenuPopup({
 
 const menuItemClassName = [
   'flex items-center text-popover-foreground',
-  'cursor-default select-none',
+  'cursor-pointer select-none',
   'data-[highlighted]:bg-popover-accent data-[selected]:bg-popover-accent',
   'data-[popup-open]:bg-popover-accent',
   'focus-visible:outline-none',
   '[&_svg:not([class*=size-])]:size-4 [&_svg:not([class*=text-])]:text-popover-foreground',
   '*:data-[slot=switch]:ml-auto',
-  'data-disabled:opacity-70 data-disabled:pointer-events-none',
+  'data-disabled:cursor-not-allowed data-disabled:opacity-70 data-disabled:pointer-events-none',
 ];
 
 export function MenuItem({

--- a/components/selia/number-field.tsx
+++ b/components/selia/number-field.tsx
@@ -64,10 +64,10 @@ export const NumberFieldGroupVariants = cva(
     '[&_svg:not([class*=size-])]:size-4.5',
     '*:[button]:size-9.5 *:[button]:flex *:[button]:items-center *:[button]:justify-center',
     '*:[button]:transition-all *:[button]:duration-100',
-    '*:[button]:text-foreground',
-    '*:[button]:disabled:opacity-70 *:[button]:disabled:pointer-events-none',
+    '*:[button]:text-foreground *:[button]:cursor-pointer',
+    '*:[button]:disabled:cursor-not-allowed *:[button]:disabled:opacity-70 *:[button]:disabled:pointer-events-none',
     '*:first:rounded-l *:last:rounded-r',
-    'data-disabled:opacity-70 data-disabled:pointer-events-none',
+    'data-disabled:cursor-not-allowed data-disabled:opacity-70 data-disabled:pointer-events-none',
   ],
   {
     variants: {

--- a/components/selia/radio.tsx
+++ b/components/selia/radio.tsx
@@ -42,11 +42,11 @@ export function Radio({
     <BaseRadio.Root
       data-slot="radio"
       className={cn(
-        'size-4 flex items-center justify-center rounded-full border border-input-border bg-input shadow-input',
+        'size-4 flex items-center justify-center rounded-full border border-input-border bg-input shadow-input cursor-pointer',
         'focus:outline-0 focus-visible:outline-2 focus-visible:outline-offset-2 outline-primary',
         'data-[checked]:bg-primary data-[checked]:border-primary',
         'transition-colors duration-75 hover:border-input-accent-border',
-        'data-disabled:opacity-70 data-disabled:pointer-events-none',
+        'data-disabled:cursor-not-allowed data-disabled:opacity-70 data-disabled:pointer-events-none',
         className,
       )}
       {...props}

--- a/components/selia/scroll-area.tsx
+++ b/components/selia/scroll-area.tsx
@@ -65,7 +65,7 @@ function ScrollAreaScrollbar({
     >
       <BaseScrollArea.Thumb
         data-slot="scroll-area-thumb"
-        className="rounded bg-scrollbar w-full"
+        className="rounded bg-scrollbar w-full cursor-grab active:cursor-grabbing"
       />
     </BaseScrollArea.Scrollbar>
   );

--- a/components/selia/select.tsx
+++ b/components/selia/select.tsx
@@ -22,8 +22,8 @@ export const selectTriggerVariants = cva(
   [
     'h-9.5 px-3.5 w-full bg-input rounded placeholder:text-dimmed transition-all',
     'focus:outline-0 focus:ring-primary focus:ring-2',
-    'flex items-center gap-2.5 cursor-default',
-    'data-disabled:opacity-70 data-disabled:pointer-events-none',
+    'flex items-center gap-2.5 cursor-pointer',
+    'data-disabled:cursor-not-allowed data-disabled:opacity-70 data-disabled:pointer-events-none',
   ],
   {
     variants: {
@@ -216,11 +216,11 @@ export function SelectItem({
       data-slot="select-item"
       value={typeof value === 'object' ? value : { value, label: children }}
       className={cn(
-        'flex items-center text-popover-foreground py-2.5 px-3 gap-3.5 rounded select-none',
+        'flex items-center text-popover-foreground py-2.5 px-3 gap-3.5 rounded select-none cursor-pointer',
         'group-data-[side=none]:min-w-[calc(var(--anchor-width))]',
         'data-[highlighted]:bg-popover-accent data-[selected]:bg-popover-accent',
         'focus-visible:outline-none',
-        'data-disabled:opacity-70 data-disabled:pointer-events-none',
+        'data-disabled:cursor-not-allowed data-disabled:opacity-70 data-disabled:pointer-events-none',
         className,
       )}
       {...props}

--- a/components/selia/slider.tsx
+++ b/components/selia/slider.tsx
@@ -28,7 +28,7 @@ export function SliderThumb({
     <BaseSlider.Thumb
       data-slot="slider-thumb"
       className={cn(
-        'size-4 bg-white ring ring-primary rounded-full shadow',
+        'size-4 bg-white ring ring-primary rounded-full shadow cursor-grab active:cursor-grabbing',
         'has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 has-[:focus-visible]:outline-foreground',
       )}
       {...props}

--- a/components/selia/switch.tsx
+++ b/components/selia/switch.tsx
@@ -11,12 +11,12 @@ export function Switch({
     <BaseSwitch.Root
       data-slot="switch"
       className={cn(
-        'w-9 h-5 rounded-full flex items-center px-0.5',
+        'w-9 h-5 rounded-full flex items-center px-0.5 cursor-pointer',
         'ring ring-input-border bg-track inset-shadow-xs inset-shadow-black/10 dark:inset-shadow-none',
         'data-checked:bg-primary data-checked:ring-primary',
         'transition-colors duration-75',
         'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary',
-        'data-disabled:opacity-70 data-disabled:pointer-events-none',
+        'data-disabled:cursor-not-allowed data-disabled:opacity-70 data-disabled:pointer-events-none',
         className,
       )}
       {...props}

--- a/components/selia/tabs.tsx
+++ b/components/selia/tabs.tsx
@@ -56,12 +56,12 @@ export function TabsItem({
     <BaseTabs.Tab
       data-slot="tabs-item"
       className={cn(
-        'flex items-center justify-center gap-2.5 rounded',
+        'flex items-center justify-center gap-2.5 rounded cursor-pointer',
         'h-8 py-1 px-3 text-muted flex-1 font-medium',
         'data-active:text-foreground',
         'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary',
         '[&_svg:not([class*=size-])]:size-4',
-        'data-disabled:opacity-70 data-disabled:pointer-events-none',
+        'data-disabled:cursor-not-allowed data-disabled:opacity-70 data-disabled:pointer-events-none',
         className,
       )}
       {...props}

--- a/components/selia/toggle.tsx
+++ b/components/selia/toggle.tsx
@@ -6,10 +6,10 @@ import { cn } from '#utils';
 
 const toggleVariants = cva(
   [
-    'inline-flex items-center justify-center gap-2.5 ring [&_svg:not([class*=size-])]:size-4.5',
+    'inline-flex items-center justify-center gap-2.5 ring [&_svg:not([class*=size-])]:size-4.5 cursor-pointer',
     'focus:outline-0 focus-visible:outline-2 focus-visible:outline-offset-2',
     'transition-colors duration-100 [&_svg:not([class*=text-])]:text-foreground',
-    'hover:bg-accent/50 data-disabled:opacity-70 data-disabled:pointer-events-none',
+    'hover:bg-accent/50 data-disabled:cursor-not-allowed data-disabled:opacity-70 data-disabled:pointer-events-none',
   ],
   {
     variants: {


### PR DESCRIPTION
## Summary

Improves UX feedback by adding appropriate cursor styles to interactive components throughout the component library.

## Changes

### Added `cursor-pointer` to clickable elements
- Button
- Checkbox
- Switch
- Radio
- TabsItem
- Toggle
- SelectTrigger & SelectItem
- ComboboxTrigger & ComboboxItem
- MenuItem and related menu components
- AutocompleteItem
- NumberField increment/decrement buttons
- Label

### Added `cursor-not-allowed` for disabled states
All interactive components now show `cursor-not-allowed` when disabled, providing clear visual feedback that the element cannot be interacted with.

### Added `cursor-progress` for loading states
- Button with `progress` prop now shows `cursor-progress`

### Added `cursor-grab` / `cursor-grabbing` for draggable elements
- SliderThumb
- ScrollAreaThumb

## Why

Previously, many interactive components used the default cursor or `cursor-default`, which made the UI feel less responsive and didn't clearly communicate interactivity to users. These changes follow standard UX conventions:

- `cursor-pointer` → "this is clickable"
- `cursor-not-allowed` → "this is disabled"
- `cursor-progress` → "action in progress"
- `cursor-grab/grabbing` → "this is draggable"