### PR TITLE
feat(drawer): add comprehensive drawer component with 7 variants

### DIFF
--- a/app/routes/docs.drawer.mdx
+++ b/app/routes/docs.drawer.mdx
@@ -1,0 +1,106 @@
+# Drawer
+
+A side panel that slides in from the edge of the screen, commonly used for navigation, filters, or additional content.
+
+<DocsButtons externalDoc="https://base-ui.com/react/components/drawer" />
+
+<Preview name="basic" />
+
+## Installation
+
+<Installation name="drawer" dependencies={["button"]} />
+
+## Usage
+
+### Import
+
+Import the component and its related parts.
+
+```ts filename="Drawer Parts"
+import {
+  Drawer,
+  DrawerTrigger,
+  DrawerPopup,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerBody,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerClose
+} from "components/selia/drawer";
+```
+
+### Structure
+
+The expected structure and composition of the component.
+
+```tsx filename="Anatomy"
+<Drawer>
+  <DrawerTrigger>Open Drawer</DrawerTrigger>
+  <DrawerPopup>
+    <DrawerHeader>
+      <DrawerTitle>Drawer Title</DrawerTitle>
+      <DrawerClose />
+    </DrawerHeader>
+    <DrawerBody>
+      <DrawerDescription>Drawer Description</DrawerDescription>
+    </DrawerBody>
+    <DrawerFooter>
+      <DrawerClose>Close</DrawerClose>
+    </DrawerFooter>
+  </DrawerPopup>
+</Drawer>
+```
+
+## Examples
+
+### Right Side Drawer (Default)
+
+A drawer that slides in from the right side. Perfect for navigation, settings, and edit forms.
+
+<Preview name="basic" />
+
+### Bottom Sheet Drawer
+
+A drawer that slides up from the bottom. Ideal for action sheets, mobile navigation, and mobile-first experiences.
+
+<Preview name="bottom" />
+
+### Left Side Drawer
+
+A drawer that slides in from the left side. Great for navigation menus and sidebars.
+
+<Preview name="left" />
+
+### Controlled Drawer
+
+Manage the drawer's open state with React state and external controls.
+
+<Preview name="controlled" />
+
+### Action Sheet
+
+A bottom drawer styled as an action sheet for selecting from a list of actions.
+
+<Preview name="actionsheet" />
+
+### Nested Drawers
+
+Stack multiple drawers for complex workflows and multi-step interactions.
+
+<Preview name="nested" />
+
+### Mobile Navigation
+
+Full-screen mobile navigation drawer with navigation items and social links.
+
+<Preview name="mobilenav" />
+
+## Accessibility
+
+The Drawer component is built on top of Base UI's Drawer, which provides:
+
+- **ARIA attributes**: Proper roles and labels for screen readers
+- **Keyboard navigation**: Dismisses on Escape key press
+- **Focus management**: Focus is trapped within the drawer while open
+- **Backdrop interaction**: Clicking the backdrop closes the drawer

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "seliaui",
       "dependencies": {
-        "@base-ui/react": "1.0.0",
+        "@base-ui/react": "^1.2.0",
         "@jsdevtools/rehype-toc": "^3.0.2",
         "@mdx-js/mdx": "^3.1.1",
         "@mdx-js/react": "^3.1.1",
@@ -116,7 +116,7 @@
 
     "@babel/preset-typescript": ["@babel/preset-typescript@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ=="],
 
-    "@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
+    "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
 
     "@babel/template": ["@babel/template@7.27.2", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/parser": "^7.27.2", "@babel/types": "^7.27.1" } }, "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw=="],
 
@@ -124,9 +124,9 @@
 
     "@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
 
-    "@base-ui/react": ["@base-ui/react@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.28.4", "@base-ui/utils": "0.2.3", "@floating-ui/react-dom": "^2.1.6", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "tabbable": "^6.3.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-4USBWz++DUSLTuIYpbYkSgy1F9ZmNG9S/lXvlUN6qMK0P0RlW+6eQmDUB4DgZ7HVvtXl4pvi4z5J2fv6Z3+9hg=="],
+    "@base-ui/react": ["@base-ui/react@1.2.0", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@base-ui/utils": "0.2.5", "@floating-ui/react-dom": "^2.1.6", "@floating-ui/utils": "^0.2.10", "tabbable": "^6.4.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-O6aEQHcm+QyGTFY28xuwRD3SEJGZOBDpyjN2WvpfWYFVhg+3zfXPysAILqtM0C1kWC82MccOE/v1j+GHXE4qIw=="],
 
-    "@base-ui/utils": ["@base-ui/utils@0.2.3", "", { "dependencies": { "@babel/runtime": "^7.28.4", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-/CguQ2PDaOzeVOkllQR8nocJ0FFIDqsWIcURsVmm53QGo8NhFNpePjNlyPIB41luxfOqnG7PU0xicMEw3ls7XQ=="],
+    "@base-ui/utils": ["@base-ui/utils@0.2.5", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@floating-ui/utils": "^0.2.10", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-oYC7w0gp76RI5MxprlGLV0wze0SErZaRl3AAkeP3OnNB/UBMb6RqNf6ZSIlxOc9Qp68Ab3C2VOcJQyRs7Xc7Vw=="],
 
     "@esbuild-plugins/node-resolve": ["@esbuild-plugins/node-resolve@0.2.2", "", { "dependencies": { "@types/resolve": "^1.17.1", "debug": "^4.3.1", "escape-string-regexp": "^4.0.0", "resolve": "^1.19.0" }, "peerDependencies": { "esbuild": "*" } }, "sha512-+t5FdX3ATQlb53UFDBRb4nqjYBz492bIrnVWvpQHpzZlu9BQL5HasMZhqc409ygUwOWCXZhrWr6NyZ6T6Y+cxw=="],
 
@@ -1630,7 +1630,7 @@
 
     "synckit": ["synckit@0.11.11", "", { "dependencies": { "@pkgr/core": "^0.2.9" } }, "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw=="],
 
-    "tabbable": ["tabbable@6.3.0", "", {}, "sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ=="],
+    "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
 
     "tailwind-csstree": ["tailwind-csstree@0.1.4", "", {}, "sha512-FzD187HuFIZEyeR7Xy6sJbJll2d4SybS90satC8SKIuaNRC05CxMvdzN7BUsfDQffcnabckRM5OIcfArjsZ0mg=="],
 
@@ -1837,6 +1837,8 @@
     "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "mdast-util-frontmatter/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "mdx-bundler/@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
 
     "mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 

--- a/components/examples/drawer/actionsheet.tsx
+++ b/components/examples/drawer/actionsheet.tsx
@@ -1,0 +1,51 @@
+import { Button } from 'components/selia/button';
+import {
+  Drawer,
+  DrawerBody,
+  DrawerClose,
+  DrawerPopup,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from 'components/selia/drawer';
+import { cn } from '#utils';
+import { Separator } from 'components/selia/separator';
+
+export default function DrawerActionSheetExample() {
+  return (
+    <Drawer>
+      <DrawerTrigger render={<Button>Open Actions</Button>} />
+      <DrawerPopup
+        className={cn(
+          '!fixed !inset-x-0 !right-auto !left-0 !top-auto !bottom-0 !w-full !max-w-none',
+          'max-h-fit rounded-t-2xl',
+        )}
+      >
+        <DrawerHeader className="pb-2">
+          <DrawerTitle>Choose an action</DrawerTitle>
+        </DrawerHeader>
+        <DrawerBody className="px-0 py-2">
+          {[
+            { label: 'Edit', icon: '✎', color: 'text-blue-600' },
+            { label: 'Copy', icon: '📋', color: 'text-gray-600' },
+            { label: 'Share', icon: '🔗', color: 'text-green-600' },
+            { label: 'Archive', icon: '📦', color: 'text-orange-600' },
+            { label: 'Delete', icon: '🗑️', color: 'text-red-600' },
+          ].map((action, idx) => (
+            <div key={action.label}>
+              <button className="w-full flex items-center justify-center gap-3 px-6 py-3.5 hover:bg-muted transition-colors text-center font-medium">
+                <span className="text-xl">{action.icon}</span>
+                <span className={action.color}>{action.label}</span>
+              </button>
+              {idx < 4 && <Separator />}
+            </div>
+          ))}
+        </DrawerBody>
+        <DrawerFooter className="px-0 py-2 border-t">
+          <DrawerClose render={<Button className="w-full" variant="secondary">Cancel</Button>} />
+        </DrawerFooter>
+      </DrawerPopup>
+    </Drawer>
+  );
+}

--- a/components/examples/drawer/basic.tsx
+++ b/components/examples/drawer/basic.tsx
@@ -1,0 +1,45 @@
+import { Button } from 'components/selia/button';
+import {
+  Drawer,
+  DrawerBody,
+  DrawerClose,
+  DrawerPopup,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from 'components/selia/drawer';
+import { Label } from 'components/selia/label';
+import { Input } from 'components/selia/input';
+
+export default function DrawerBasicExample() {
+  return (
+    <Drawer>
+      <DrawerTrigger render={<Button>Open Drawer</Button>} />
+      <DrawerPopup>
+        <DrawerHeader>
+          <DrawerTitle>Edit Profile</DrawerTitle>
+          <DrawerClose />
+        </DrawerHeader>
+        <DrawerBody>
+          <DrawerDescription>Update your profile information.</DrawerDescription>
+          <div className="space-y-4 mt-4">
+            <div>
+              <Label>Full Name</Label>
+              <Input placeholder="John Doe" className="mt-1.5" />
+            </div>
+            <div>
+              <Label>Email</Label>
+              <Input type="email" placeholder="john@example.com" className="mt-1.5" />
+            </div>
+          </div>
+        </DrawerBody>
+        <DrawerFooter>
+          <Button variant="secondary">Cancel</Button>
+          <Button>Save Profile</Button>
+        </DrawerFooter>
+      </DrawerPopup>
+    </Drawer>
+  );
+}

--- a/components/examples/drawer/bottom.tsx
+++ b/components/examples/drawer/bottom.tsx
@@ -1,0 +1,57 @@
+import { Button } from 'components/selia/button';
+import {
+  Drawer,
+  DrawerBody,
+  DrawerClose,
+  DrawerPopup,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from 'components/selia/drawer';
+import { cn } from '#utils';
+
+export default function DrawerBottomExample() {
+  return (
+    <Drawer>
+      <DrawerTrigger render={<Button>Open Bottom Sheet</Button>} />
+      <DrawerPopup
+        className={cn(
+          '!fixed !inset-x-0 !right-auto !left-0 !top-auto !bottom-0 !w-full !max-w-none !rounded-t-2xl',
+          'max-h-[80vh]'
+        )}
+      >
+        <DrawerHeader className="border-b">
+          <DrawerTitle>Choose an Action</DrawerTitle>
+          <DrawerClose />
+        </DrawerHeader>
+        <DrawerBody>
+          <DrawerDescription>Select one of the options below</DrawerDescription>
+          <div className="space-y-2 mt-4">
+            {[
+              { icon: '✓', label: 'Approve Request', desc: 'Accept this action' },
+              { icon: '✎', label: 'Edit Details', desc: 'Modify information' },
+              { icon: '⊕', label: 'Add Comment', desc: 'Leave feedback' },
+              { icon: '⌛', label: 'Postpone', desc: 'Defer until later' },
+            ].map((action) => (
+              <button
+                key={action.label}
+                className="w-full flex items-center gap-3 p-3.5 rounded-lg hover:bg-muted transition-colors text-left"
+              >
+                <span className="text-xl">{action.icon}</span>
+                <div>
+                  <div className="font-medium">{action.label}</div>
+                  <div className="text-sm text-muted">{action.desc}</div>
+                </div>
+              </button>
+            ))}
+          </div>
+        </DrawerBody>
+        <DrawerFooter className="border-t">
+          <DrawerClose render={<Button variant="secondary">Cancel</Button>} />
+        </DrawerFooter>
+      </DrawerPopup>
+    </Drawer>
+  );
+}

--- a/components/examples/drawer/controlled.tsx
+++ b/components/examples/drawer/controlled.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from 'components/selia/button';
+import {
+  Drawer,
+  DrawerBody,
+  DrawerClose,
+  DrawerPopup,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from 'components/selia/drawer';
+
+export default function DrawerControlledExample() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Drawer open={open} onOpenChange={setOpen}>
+      <DrawerTrigger render={<Button>Open Controlled Drawer</Button>} />
+      <DrawerPopup>
+        <DrawerHeader>
+          <DrawerTitle>Drawer State</DrawerTitle>
+          <DrawerClose />
+        </DrawerHeader>
+        <DrawerBody>
+          <DrawerDescription>
+            This drawer's state is managed externally using React state.
+          </DrawerDescription>
+          <div className="mt-4 p-4 bg-muted rounded-lg">
+            <p className="text-sm">
+              <strong>Open state:</strong> {open ? 'Open' : 'Closed'}
+            </p>
+            <p className="text-sm text-muted mt-2">
+              You can control when the drawer opens/closes from your application.
+            </p>
+          </div>
+        </DrawerBody>
+        <DrawerFooter>
+          <Button
+            variant="secondary"
+            onClick={() => setOpen(false)}
+          >
+            Close Drawer
+          </Button>
+          <Button onClick={() => setOpen(false)}>
+            Confirm & Close
+          </Button>
+        </DrawerFooter>
+      </DrawerPopup>
+    </Drawer>
+  );
+}

--- a/components/examples/drawer/index.ts
+++ b/components/examples/drawer/index.ts
@@ -1,0 +1,67 @@
+import React from 'react';
+
+export const examples = {
+  basic: {
+    name: 'Basic',
+    path: 'components/examples/drawer/basic.tsx',
+    component: React.lazy(() =>
+      import('./basic').then((mod) => ({
+        default: mod.default,
+      })),
+    ),
+  },
+  bottom: {
+    name: 'Bottom',
+    path: 'components/examples/drawer/bottom.tsx',
+    component: React.lazy(() =>
+      import('./bottom').then((mod) => ({
+        default: mod.default,
+      })),
+    ),
+  },
+  left: {
+    name: 'Left',
+    path: 'components/examples/drawer/left.tsx',
+    component: React.lazy(() =>
+      import('./left').then((mod) => ({
+        default: mod.default,
+      })),
+    ),
+  },
+  controlled: {
+    name: 'Controlled',
+    path: 'components/examples/drawer/controlled.tsx',
+    component: React.lazy(() =>
+      import('./controlled').then((mod) => ({
+        default: mod.default,
+      })),
+    ),
+  },
+  actionsheet: {
+    name: 'Action Sheet',
+    path: 'components/examples/drawer/actionsheet.tsx',
+    component: React.lazy(() =>
+      import('./actionsheet').then((mod) => ({
+        default: mod.default,
+      })),
+    ),
+  },
+  nested: {
+    name: 'Nested',
+    path: 'components/examples/drawer/nested.tsx',
+    component: React.lazy(() =>
+      import('./nested').then((mod) => ({
+        default: mod.default,
+      })),
+    ),
+  },
+  mobilenav: {
+    name: 'Mobile Navigation',
+    path: 'components/examples/drawer/mobilenav.tsx',
+    component: React.lazy(() =>
+      import('./mobilenav').then((mod) => ({
+        default: mod.default,
+      })),
+    ),
+  },
+};

--- a/components/examples/drawer/left.tsx
+++ b/components/examples/drawer/left.tsx
@@ -1,0 +1,52 @@
+import { Button } from 'components/selia/button';
+import {
+  Drawer,
+  DrawerBody,
+  DrawerClose,
+  DrawerPopup,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from 'components/selia/drawer';
+import { cn } from '#utils';
+
+export default function DrawerLeftExample() {
+  return (
+    <Drawer>
+      <DrawerTrigger render={<Button variant="secondary">Open Left Drawer</Button>} />
+      <DrawerPopup
+        className={cn(
+          '!fixed !inset-y-0 !left-0 !right-auto !top-0 !w-full !max-w-md',
+          'data-[starting-style]:-translate-x-full data-[ending-style]:-translate-x-full',
+        )}
+      >
+        <DrawerHeader>
+          <DrawerTitle>Navigation Menu</DrawerTitle>
+          <DrawerClose />
+        </DrawerHeader>
+        <DrawerBody>
+          <DrawerDescription>Select a page to navigate</DrawerDescription>
+          <nav className="space-y-2 mt-4">
+            {[
+              { label: 'Dashboard', icon: '📊' },
+              { label: 'Analytics', icon: '📈' },
+              { label: 'Reports', icon: '📋' },
+              { label: 'Settings', icon: '⚙️' },
+              { label: 'Help', icon: '❓' },
+            ].map((item) => (
+              <button
+                key={item.label}
+                className="w-full flex items-center gap-3 px-4 py-3 rounded-lg hover:bg-muted transition-colors text-left font-medium"
+              >
+                <span className="text-lg">{item.icon}</span>
+                {item.label}
+              </button>
+            ))}
+          </nav>
+        </DrawerBody>
+      </DrawerPopup>
+    </Drawer>
+  );
+}

--- a/components/examples/drawer/mobilenav.tsx
+++ b/components/examples/drawer/mobilenav.tsx
@@ -1,0 +1,76 @@
+import { Button } from 'components/selia/button';
+import {
+  Drawer,
+  DrawerBody,
+  DrawerClose,
+  DrawerPopup,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from 'components/selia/drawer';
+import { cn } from '#utils';
+import { XIcon } from 'lucide-react';
+
+export default function DrawerMobileNavExample() {
+  const navItems = [
+    { label: 'Home', icon: '🏠' },
+    { label: 'Products', icon: '📦' },
+    { label: 'Services', icon: '🔧' },
+    { label: 'About', icon: 'ℹ️' },
+    { label: 'Contact', icon: '📞' },
+  ];
+
+  const socialLinks = [
+    { label: 'Twitter', icon: '𝕏' },
+    { label: 'GitHub', icon: '🐙' },
+    { label: 'LinkedIn', icon: '💼' },
+  ];
+
+  return (
+    <Drawer>
+      <DrawerTrigger render={<Button>≡ Menu</Button>} />
+      <DrawerPopup
+        className={cn(
+          '!fixed !inset-y-0 !left-0 !right-auto !top-0 !w-full !max-w-xs',
+          'data-[starting-style]:-translate-x-full data-[ending-style]:-translate-x-full',
+        )}
+      >
+        <DrawerHeader className="border-b flex items-center justify-between">
+          <DrawerTitle>Navigation</DrawerTitle>
+          <DrawerClose render={<XIcon className="size-5" />} />
+        </DrawerHeader>
+        <DrawerBody className="px-0 py-4">
+          <nav className="space-y-1">
+            {navItems.map((item) => (
+              <button
+                key={item.label}
+                className="w-full flex items-center gap-3 px-6 py-3 hover:bg-muted transition-colors text-left font-medium"
+              >
+                <span className="text-lg">{item.icon}</span>
+                {item.label}
+              </button>
+            ))}
+          </nav>
+        </DrawerBody>
+        <DrawerFooter className="!flex-col gap-4 border-t">
+          <div className="w-full">
+            <p className="text-xs font-semibold text-muted mb-3">FOLLOW US</p>
+            <div className="flex gap-2">
+              {socialLinks.map((link) => (
+                <button
+                  key={link.label}
+                  className="flex-1 flex items-center justify-center gap-2 px-3 py-2 bg-muted rounded-lg hover:bg-muted/80 transition-colors text-sm font-medium"
+                >
+                  <span>{link.icon}</span>
+                  <span className="hidden sm:inline">{link.label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+          <DrawerClose render={<Button className="w-full">Close</Button>} />
+        </DrawerFooter>
+      </DrawerPopup>
+    </Drawer>
+  );
+}

--- a/components/examples/drawer/nested.tsx
+++ b/components/examples/drawer/nested.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from 'components/selia/button';
+import {
+  Drawer,
+  DrawerBody,
+  DrawerClose,
+  DrawerPopup,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from 'components/selia/drawer';
+
+export default function DrawerNestedExample() {
+  const [showNested, setShowNested] = useState(false);
+
+  return (
+    <Drawer>
+      <DrawerTrigger render={<Button>Open Parent Drawer</Button>} />
+      <DrawerPopup>
+        <DrawerHeader>
+          <DrawerTitle>Parent Drawer</DrawerTitle>
+          <DrawerClose />
+        </DrawerHeader>
+        <DrawerBody>
+          <DrawerDescription>
+            This drawer can contain nested drawers. Click the button below to open a nested drawer.
+          </DrawerDescription>
+          <div className="mt-6">
+            <Drawer open={showNested} onOpenChange={setShowNested}>
+              <DrawerTrigger render={<Button className="w-full">Open Nested Drawer</Button>} />
+              <DrawerPopup>
+                <DrawerHeader>
+                  <DrawerTitle>Nested Drawer</DrawerTitle>
+                  <DrawerClose />
+                </DrawerHeader>
+                <DrawerBody>
+                  <DrawerDescription>
+                    You can stack multiple drawers for complex workflows.
+                  </DrawerDescription>
+                  <div className="mt-4 p-3 bg-muted rounded-lg">
+                    <p className="text-sm font-medium">This is a nested drawer</p>
+                    <p className="text-xs text-muted mt-1">
+                      It appears on top of the parent drawer. Close this to return to the parent.
+                    </p>
+                  </div>
+                </DrawerBody>
+                <DrawerFooter>
+                  <Button
+                    variant="secondary"
+                    onClick={() => setShowNested(false)}
+                  >
+                    Close Nested
+                  </Button>
+                </DrawerFooter>
+              </DrawerPopup>
+            </Drawer>
+          </div>
+        </DrawerBody>
+        <DrawerFooter>
+          <DrawerClose render={<Button variant="secondary">Close</Button>} />
+        </DrawerFooter>
+      </DrawerPopup>
+    </Drawer>
+  );
+}

--- a/components/examples/index.ts
+++ b/components/examples/index.ts
@@ -19,6 +19,7 @@ export { examples as checkbox } from './checkbox';
 export { examples as chip } from './chip';
 export { examples as combobox } from './combobox';
 export { examples as dialog } from './dialog';
+export { examples as drawer } from './drawer';
 export { examples as divider } from './divider';
 export { examples as menu } from './menu';
 export { examples as field } from './field';

--- a/components/selia/drawer.tsx
+++ b/components/selia/drawer.tsx
@@ -1,24 +1,24 @@
 'use client';
 
-import { Dialog as BaseDialog } from '@base-ui/react/dialog';
+import { DrawerPreview as BaseDrawer } from '@base-ui/react/drawer';
 import { buttonVariants } from './button';
 import { cn } from '#utils';
 import { XIcon } from 'lucide-react';
 
 export function Drawer({
   ...props
-}: React.ComponentProps<typeof BaseDialog.Root>) {
-  return <BaseDialog.Root data-slot="drawer" {...props} />;
+}: React.ComponentProps<typeof BaseDrawer.Root>) {
+  return <BaseDrawer.Root data-slot="drawer" swipeDirection="right" {...props} />;
 }
 
 export function DrawerTrigger({
   children,
   ...props
-}: React.ComponentProps<typeof BaseDialog.Trigger>) {
+}: React.ComponentProps<typeof BaseDrawer.Trigger>) {
   return (
-    <BaseDialog.Trigger data-slot="drawer-trigger" {...props}>
+    <BaseDrawer.Trigger data-slot="drawer-trigger" {...props}>
       {children}
-    </BaseDialog.Trigger>
+    </BaseDrawer.Trigger>
   );
 }
 
@@ -26,30 +26,34 @@ export function DrawerPopup({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof BaseDialog.Popup>) {
+}: React.ComponentProps<typeof BaseDrawer.Popup>) {
   return (
-    <BaseDialog.Portal>
-      <BaseDialog.Backdrop
+    <BaseDrawer.Portal>
+      <BaseDrawer.Backdrop
         className={cn(
           'fixed inset-0 min-h-dvh bg-black/60 transition-[color,opacity] backdrop-blur-sm',
           'data-[starting-style]:opacity-0 data-[ending-style]:opacity-0',
         )}
       />
-      <BaseDialog.Popup
-        data-slot="drawer-popup"
-        {...props}
-        className={cn(
-          'fixed inset-y-0 right-0 w-full max-w-md',
-          'bg-dialog text-dialog-foreground backdrop-blur-sm',
-          'shadow-lg outline-none transition-all',
-          'data-[starting-style]:translate-x-full data-[ending-style]:translate-x-full',
-          'flex flex-col',
-          className,
-        )}
+      <BaseDrawer.Viewport
+        className={cn('fixed inset-y-0 right-0 w-full max-w-md')}
       >
-        {children}
-      </BaseDialog.Popup>
-    </BaseDialog.Portal>
+        <BaseDrawer.Popup
+          data-slot="drawer-popup"
+          {...props}
+          className={cn(
+            'w-full h-full',
+            'bg-dialog text-dialog-foreground backdrop-blur-sm',
+            'shadow-lg outline-none transition-all',
+            'data-[swiping]:transition-none',
+            'flex flex-col',
+            className,
+          )}
+        >
+          {children}
+        </BaseDrawer.Popup>
+      </BaseDrawer.Viewport>
+    </BaseDrawer.Portal>
   );
 }
 
@@ -73,15 +77,15 @@ export function DrawerTitle({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof BaseDialog.Title>) {
+}: React.ComponentProps<typeof BaseDrawer.Title>) {
   return (
-    <BaseDialog.Title
+    <BaseDrawer.Title
       data-slot="drawer-title"
       {...props}
       className={cn('text-xl font-semibold', className)}
     >
       {children}
-    </BaseDialog.Title>
+    </BaseDrawer.Title>
   );
 }
 
@@ -105,15 +109,15 @@ export function DrawerDescription({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof BaseDialog.Description>) {
+}: React.ComponentProps<typeof BaseDrawer.Description>) {
   return (
-    <BaseDialog.Description
+    <BaseDrawer.Description
       data-slot="drawer-description"
       {...props}
       className={cn('text-muted leading-relaxed', className)}
     >
       {children}
-    </BaseDialog.Description>
+    </BaseDrawer.Description>
   );
 }
 
@@ -142,15 +146,15 @@ export function DrawerClose({
   children,
   render,
   ...props
-}: React.ComponentProps<typeof BaseDialog.Close>) {
+}: React.ComponentProps<typeof BaseDrawer.Close>) {
   return (
-    <BaseDialog.Close
+    <BaseDrawer.Close
       data-slot="drawer-close"
       render={render}
       {...props}
       className={cn(!render && buttonVariants({ variant: 'plain' }), className)}
     >
       {children || <XIcon className="size-5" />}
-    </BaseDialog.Close>
+    </BaseDrawer.Close>
   );
 }

--- a/components/selia/drawer.tsx
+++ b/components/selia/drawer.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { Dialog as BaseDialog } from '@base-ui/react/dialog';
+import { buttonVariants } from './button';
+import { cn } from '#utils';
+import { XIcon } from 'lucide-react';
+
+export function Drawer({
+  ...props
+}: React.ComponentProps<typeof BaseDialog.Root>) {
+  return <BaseDialog.Root data-slot="drawer" {...props} />;
+}
+
+export function DrawerTrigger({
+  children,
+  ...props
+}: React.ComponentProps<typeof BaseDialog.Trigger>) {
+  return (
+    <BaseDialog.Trigger data-slot="drawer-trigger" {...props}>
+      {children}
+    </BaseDialog.Trigger>
+  );
+}
+
+export function DrawerPopup({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof BaseDialog.Popup>) {
+  return (
+    <BaseDialog.Portal>
+      <BaseDialog.Backdrop
+        className={cn(
+          'fixed inset-0 min-h-dvh bg-black/60 transition-[color,opacity] backdrop-blur-sm',
+          'data-[starting-style]:opacity-0 data-[ending-style]:opacity-0',
+        )}
+      />
+      <BaseDialog.Popup
+        data-slot="drawer-popup"
+        {...props}
+        className={cn(
+          'fixed inset-y-0 right-0 w-full max-w-md',
+          'bg-dialog text-dialog-foreground backdrop-blur-sm',
+          'shadow-lg outline-none transition-all',
+          'data-[starting-style]:translate-x-full data-[ending-style]:translate-x-full',
+          'flex flex-col',
+          className,
+        )}
+      >
+        {children}
+      </BaseDialog.Popup>
+    </BaseDialog.Portal>
+  );
+}
+
+export function DrawerHeader({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<'header'>) {
+  return (
+    <header
+      data-slot="drawer-header"
+      {...props}
+      className={cn('px-6 pt-4.5 flex items-center justify-between gap-3.5', className)}
+    >
+      {children}
+    </header>
+  );
+}
+
+export function DrawerTitle({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof BaseDialog.Title>) {
+  return (
+    <BaseDialog.Title
+      data-slot="drawer-title"
+      {...props}
+      className={cn('text-xl font-semibold', className)}
+    >
+      {children}
+    </BaseDialog.Title>
+  );
+}
+
+export function DrawerBody({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="drawer-body"
+      {...props}
+      className={cn('px-6 py-4.5 space-y-1.5 flex-1 overflow-y-auto', className)}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function DrawerDescription({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof BaseDialog.Description>) {
+  return (
+    <BaseDialog.Description
+      data-slot="drawer-description"
+      {...props}
+      className={cn('text-muted leading-relaxed', className)}
+    >
+      {children}
+    </BaseDialog.Description>
+  );
+}
+
+export function DrawerFooter({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<'footer'>) {
+  return (
+    <footer
+      data-slot="drawer-footer"
+      {...props}
+      className={cn(
+        'flex items-center justify-end gap-1.5',
+        'px-6 py-3.5 bg-dialog-footer border-t border-dialog-border rounded-b-xl',
+        className,
+      )}
+    >
+      {children}
+    </footer>
+  );
+}
+
+export function DrawerClose({
+  className,
+  children,
+  render,
+  ...props
+}: React.ComponentProps<typeof BaseDialog.Close>) {
+  return (
+    <BaseDialog.Close
+      data-slot="drawer-close"
+      render={render}
+      {...props}
+      className={cn(!render && buttonVariants({ variant: 'plain' }), className)}
+    >
+      {children || <XIcon className="size-5" />}
+    </BaseDialog.Close>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "typecheck": "bunx --bun react-router typegen && tsc"
   },
   "dependencies": {
-    "@base-ui/react": "1.0.0",
+    "@base-ui/react": "^1.2.0",
     "@jsdevtools/rehype-toc": "^3.0.2",
     "@mdx-js/mdx": "^3.1.1",
     "@mdx-js/react": "^3.1.1",


### PR DESCRIPTION
Implement a flexible Drawer component inspired by base-ui with multiple positioning and use-case variants:

![ezgif-438aab15894ed6c0](https://github.com/user-attachments/assets/88a8553a-08b5-479f-b0db-8ca2d22ec2f1)


Drawer Variants:
- Right-side drawer (default) - navigation, settings, forms
- Bottom sheet drawer - mobile-first, action sheets
- Left-side drawer - navigation menu
- Controlled drawer - React state management
- Action sheet - mobile action list
- Nested drawers - stacked multi-step workflows
- Mobile navigation - full-screen nav with links

Features:
- Drawer root component with composable sub-components
- Header, Title, Body, Description, Footer, Close parts
- Built on Dialog primitives with smooth animations
- Customizable positioning via className overrides
- Support light/dark mode and responsive design
- Complete examples and documentation

## Summary

Add a comprehensive Drawer component (#23) with 7 different variants and 
positioning options, inspired by base-ui's drawer implementation. Supports 
right, left, and bottom positioning with examples for common use cases.

## New Files

**Component:**
- `components/selia/drawer.tsx` - Main drawer component

**Examples (7 variants):**
- `components/examples/drawer/basic.tsx` - Right-side drawer
- `components/examples/drawer/bottom.tsx` - Bottom sheet
- `components/examples/drawer/left.tsx` - Left-side menu
- `components/examples/drawer/controlled.tsx` - Controlled state
- `components/examples/drawer/actionsheet.tsx` - Action sheet
- `components/examples/drawer/nested.tsx` - Nested drawers
- `components/examples/drawer/mobilenav.tsx` - Mobile navigation

**Documentation:**
- `app/routes/docs.drawer.mdx` - Complete guide with all examples

## Features

✅ **Drawer Component Parts**
- Drawer, DrawerTrigger, DrawerPopup
- DrawerHeader, DrawerTitle, DrawerBody
- DrawerDescription, DrawerFooter, DrawerClose

✅ **Positioning Variants**
- Right-side (default) - slides from right
- Left-side - slides from left  
- Bottom - slides up from bottom
- Customizable via className overrides

✅ **Use Case Examples**
- **Basic**: Profile editor with form inputs
- **Bottom Sheet**: Mobile action menu
- **Left Menu**: Navigation with icons
- **Controlled**: External state management with React
- **Action Sheet**: Styled action list
- **Nested**: Multi-step workflows
- **Mobile Nav**: Full-screen navigation with social links

✅ **Accessibility**
- ARIA attributes and semantic markup
- Focus trapping and keyboard navigation
- Backdrop dismissal
- Escape key to close

## Testing

Navigate to `/docs/drawer` to:
- View all 7 examples
- Test different positions (right, left, bottom)
- Try controlled state management
- Test nested drawer stacking
- Verify keyboard navigation (Escape to close)
- Test on mobile and desktop screens


Closes #23