### PR TITLE
fix(code-block): shrink short snippets to content height

### DIFF
--- a/components/code-block.tsx
+++ b/components/code-block.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useThemeStore } from '~/lib/theme-store';
 import { ScrollArea } from 'components/selia/scroll-area';
 import ShikiHighlighter from 'react-shiki/core';
@@ -26,7 +28,7 @@ export function CodeBlock({
       : 'light';
 
   return (
-    <ScrollArea className={cn(className)}>
+    <ScrollArea className={cn('max-h-[600px]', className)} scrollbar="both" fitContent>
       <ShikiHighlighter
         language={language}
         theme={{
@@ -35,7 +37,7 @@ export function CodeBlock({
         }}
         defaultColor="light"
         className={cn(
-          '**:[pre]:!p-0 **:[pre]:!overflow-visible **:[pre]:!bg-transparent **:[pre]:!outline-none',
+          '!bg-transparent **:[pre]:!p-0 **:[pre]:!bg-transparent **:[pre]:!outline-none **:[pre]:!w-max **:[pre]:!min-w-full',
           syntaxClassName,
         )}
         showLanguage={false}

--- a/components/code-tabs.tsx
+++ b/components/code-tabs.tsx
@@ -93,8 +93,8 @@ export function CodeTabsPanel({
   language?: string;
 }) {
   return (
-    <TabsPanel value={value} keepMounted className="w-full outline-none">
-      <CodeBlock language={language} className="px-4 py-4">
+    <TabsPanel value={value} keepMounted className="w-full outline-none p-4">
+      <CodeBlock language={language}>
         {getTextFromChildren(children)}
       </CodeBlock>
     </TabsPanel>

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -1,4 +1,4 @@
-import { ScrollArea } from '@base-ui/react';
+import { ScrollArea } from 'components/selia/scroll-area';
 import { CodeTabs, CodeTabsPanel } from 'components/code-tabs';
 import { CopyButton } from 'components/copy-button';
 import { cn } from 'lib/utils';
@@ -36,32 +36,34 @@ export default {
         </header>
         <div
           className={cn(
-            'relative w-full **:[code,pre]:outline-none flex flex-col',
+            'relative w-full **:[code,pre]:outline-none',
             '**:[code]:w-full **:[code]:inline-block',
           )}
         >
-          <ScrollArea.Root
-            className={cn(
-              clip && !isClipOpen
-                ? 'h-72 overflow-hidden pointer-events-none'
-                : '',
-            )}
-          >
-            <ScrollArea.Viewport className="px-4 py-4 rounded-3xl h-full">
+          <ScrollArea className="max-h-[400px]" scrollbar="both" fitContent>
+            <div
+              className={cn(
+                'px-4 py-4 rounded-3xl',
+                clip && !isClipOpen
+                  ? 'pointer-events-none'
+                  : '',
+              )}
+            >
               <pre
                 {...props}
                 className={cn(
-                  'shiki [&:has(.highlighted)_.line:not(.highlighted)]:opacity-70 hover:[&_.line]:!opacity-100',
+                  'shiki !m-0 !p-0 [&:has(.highlighted)_.line:not(.highlighted)]:opacity-70 hover:[&_.line]:!opacity-100',
                   '[&_.highlighted]:bg-linear-to-r [&_.highlighted]:from-primary/20 [&_.highlighted]:to-primary/5',
                   '[&_.highlighted]:border-l-2 [&_.highlighted]:border-primary',
                   '[&_.highlighted]:-m-4 [&_.highlighted]:pl-4 [&_.highlighted]:transition-opacity',
                   '[&_.highlighted]:w-[calc(100%+2rem)] [&_.highlighted]:inline-block',
+                  '!w-max !min-w-full',
                 )}
               >
                 {children}
               </pre>
-            </ScrollArea.Viewport>
-          </ScrollArea.Root>
+            </div>
+          </ScrollArea>
           {clip && (
             <button
               className={cn(

--- a/components/preview.tsx
+++ b/components/preview.tsx
@@ -128,7 +128,7 @@ export function PreviewCode({
           {isCopied ? <CheckIcon /> : <ClipboardIcon />}
         </Button>
       </div>
-      <CodeBlock language="tsx" className="h-[500px]">
+      <CodeBlock language="tsx">
         {children}
       </CodeBlock>
     </div>

--- a/components/selia/scroll-area.tsx
+++ b/components/selia/scroll-area.tsx
@@ -7,9 +7,11 @@ export function ScrollArea({
   children,
   className,
   scrollbar = 'both',
+  fitContent = false,
   ...props
 }: React.ComponentProps<typeof BaseScrollArea.Root> & {
   scrollbar?: 'horizontal' | 'vertical' | 'both' | false;
+  fitContent?: boolean;
 }) {
   return (
     <BaseScrollArea.Root
@@ -19,7 +21,10 @@ export function ScrollArea({
     >
       <BaseScrollArea.Viewport
         data-slot="scroll-area-viewport"
-        className="overscroll-contain outline-none size-full"
+        className={cn(
+          'overscroll-contain outline-none w-full',
+          fitContent ? 'max-h-[inherit]' : 'h-full',
+        )}
       >
         {children}
       </BaseScrollArea.Viewport>
@@ -50,22 +55,36 @@ function ScrollAreaScrollbar({
       {...props}
       data-slot="scroll-area-scrollbar"
       className={cn(
-        'flex m-1 touch-none select-none',
-        'opacity-0 transition-opacity delay-300 pointer-events-none',
-        'data-[hovering]:opacity-100 data-[hovering]:delay-0',
-        'data-[hovering]:duration-75 data-[hovering]:pointer-events-auto',
-        'data-[scrolling]:opacity-100 data-[scrolling]:delay-0',
-        'data-[scrolling]:duration-75 data-[scrolling]:pointer-events-auto',
+        'flex touch-none select-none transition-opacity delay-300 pointer-events-none opacity-0',
+        'data-[hovering]:opacity-100 data-[hovering]:delay-0 data-[hovering]:duration-75 data-[hovering]:pointer-events-auto',
+        'data-[scrolling]:opacity-100 data-[scrolling]:delay-0 data-[scrolling]:duration-75 data-[scrolling]:pointer-events-auto',
         orientation === 'vertical'
-          ? 'w-1.5 justify-center'
-          : 'h-1.5 justify-start',
+          ? 'flex-col w-1.5'
+          : 'flex-row h-1.5',
         className,
       )}
       orientation={orientation}
+      style={{
+        position: 'absolute',
+        ...(orientation === 'vertical'
+          ? {
+              right: '0.25rem',
+              top: '0.25rem',
+              height: 'calc(100% - 1rem)',
+            }
+          : {
+              bottom: '0.25rem',
+              left: '0.25rem',
+              width: 'calc(100% - 1rem)',
+            }),
+      }}
     >
       <BaseScrollArea.Thumb
         data-slot="scroll-area-thumb"
-        className="rounded bg-scrollbar w-full cursor-grab active:cursor-grabbing"
+        className={cn(
+          'rounded-full bg-scrollbar cursor-grab active:cursor-grabbing',
+          orientation === 'vertical' ? 'w-full' : 'h-full',
+        )}
       />
     </BaseScrollArea.Scrollbar>
   );


### PR DESCRIPTION
Closes #27 
## Description
### Problem
Code snippets were effectively constrained to a fixed preview height (h-72 / 288px), even for very short examples. This created large empty space and showed a "Show Code" button when it was not actually needed. The expected behavior is for short snippets to size to content, and only show expansion controls when content truly exceeds a reasonable height.

### Changes Made
- Removed fixed-height behavior for short snippets so code blocks now shrink to their content instead of reserving large empty space.
- Kept a bounded max-height for larger snippets so only genuinely long content requires scrolling/expansion.
- Updated code block rendering paths (including MDX usage) to consistently use content-fit sizing.
- Restored and aligned custom scrollbar behavior on both axes as part of the fix, ensuring long snippets still scroll correctly with the intended appearance.

### Before vs After
<!-- Short snippets -->
**Short Snippets**

<img width="1546" height="850" alt="Before short snippet" src="https://github.com/user-attachments/assets/a64b8f20-8392-4e5d-9260-d9d1c25e78a0" />

<img width="1639" height="683" alt="After short snippet" src="https://github.com/user-attachments/assets/e18ee587-9d07-4838-819b-cf10432f3ea2" />

<!-- Long snippets - vertical scroll -->
**Long Snippets (Vertical Scroll)**

<img width="1503" height="880" alt="Long snippet still scrolls vertically" src="https://github.com/user-attachments/assets/e6067523-afa0-43b6-ae4a-ad88997d6ba6" />

### Testing
- [ ] Short snippets shrink to content height
- [ ] Long snippets scroll vertically with custom scrollbar
- [ ] Long snippets scroll horizontally with custom scrollbar
- [ ] Scrollbar fades in on hover, fades out on mouse leave
- [ ] Scrollbar ends are rounded
- [ ] Scrollbar stays within container bounds
- [ ] No unrelated file changes
