### PR TITLE
ci: auto-purge Cloudflare cache after deploy

### DIFF
--- a/.github/workflows/purge-cache.yml
+++ b/.github/workflows/purge-cache.yml
@@ -1,0 +1,20 @@
+name: Purge Cloudflare Cache
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for Cloudflare Pages deploy
+        run: sleep 90
+
+      - name: Purge cache
+        run: |
+          curl -s -X POST \
+            "https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE_ID }}/purge_cache" \
+            -H "Authorization: Bearer ${{ secrets.CF_API_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            --data '{"purge_everything":true}'


### PR DESCRIPTION
## Summary

- Adds a GitHub Action that purges the Cloudflare cache after every push to master
- Waits 90 seconds for Cloudflare Pages to finish deploying, then calls the purge API
- Uses `CF_ZONE_ID` and `CF_API_TOKEN` repo secrets (already configured)

## Test plan

- [ ] Merge to master and verify cache is purged automatically